### PR TITLE
fix: drawer type bug

### DIFF
--- a/apps/www/registry/stories/drawer.stories.tsx
+++ b/apps/www/registry/stories/drawer.stories.tsx
@@ -41,7 +41,7 @@ const meta: Meta<typeof Drawer> = {
   parameters: {
     layout: "centered",
   },
-} satisfies Meta<typeof Drawer>
+}
 
 export default meta
 


### PR DESCRIPTION
drawer meta has both ´satisfies Meta<typeof Drawer>´ and ´:Meta<typeof Drawer>´